### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Add following code in your `<project-directory>/ios/Runner/Info.plist`
 <key>NSAppTransportSecurity</key>
   <dict>
     <key>NSAllowsArbitraryLoads</key> <true/>
-  </dict>Example
+  </dict>
 <key>io.flutter.embedded_views_preview</key> <true/> 
 ```
 


### PR DESCRIPTION
'Example' word causes issues as that word is not supposed to be there. By copying the whole text, the flutter run will stop working and it will cause issues.